### PR TITLE
Update NERSC instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You  need to modify class Makefile. Change compiler options to the following:
 
 Compile class first. Then, pip install python interface
 
-    cd class_public; make class
+    cd class_public; make class; make libclass.a
     cd python; python3 -m pip install .
     cd ../..
     git clone git@github.com:schoeneberg/lym1d.git

--- a/README.md
+++ b/README.md
@@ -32,15 +32,26 @@ In the case of NERSC use, this can point to `/global/cfs/cdirs/desi/science/lya/
 
 ##### Specific NERSC installation instructions
 
-    env MPICC=/opt/cray/pe/mpich/8.1.28/ofi/gnu/12.3/bin/mpicc conda install pip cython numpy scipy mpi4py
-    rm /global/homes/<firstletter_user_directory>/<your_user_directory>/.conda/envs/TEST/compiler_compat/ld
+    conda create -n lym1d python=3.11 cython numpy scipy
+    conda activate lym1d
+    MPICC="cc -shared" pip install --force-reinstall --no-cache-dir --no-binary=mpi4py mpi4py
     git clone git@github.com:schoeneberg/montepython_public_lyadesi.git
     git clone git@github.com:lesgourg/class_public.git
-    cd class_public; make -j
+
+You  need to modify class Makefile. Change compiler options to the following:
+
+    CC       = cc
+    #CC       = icc
+    #CC       = pgcc
+    CPP      = CC --std=c++11 -fpermissive -Wno-write-strings
+
+Compile class first. Then, pip install python interface
+
+    cd class_public; make class
     cd python; python3 -m pip install .
     cd ../..
     git clone git@github.com:schoeneberg/lym1d.git
-    cd lym1d; python3 -m pip install . ; cd ..
+    cd lym1d; python3 -m pip install -e . ; cd ..
 
 ##### What should my run configuration look like?
 


### PR DESCRIPTION
I updated the installation instructions. I find that removing the linker is not needed, but you need to slightly adjust the Makefile of class. `make -j` installs the python package in a deprecated way (`python setup.py install` is far gone). So I think class should be compiled, then python module should be installed separately with pip install. I changed lym1d installation to editable. 

In the future, we might want to load the CPU module first in the beginning if we are going to use CPUs for analysis. This might enable further small optimizations by the compiler.